### PR TITLE
fix: guard API client auth and frame data handling

### DIFF
--- a/__tests__/toolbar-integration.test.tsx
+++ b/__tests__/toolbar-integration.test.tsx
@@ -39,6 +39,11 @@ describe('Toolbar Integration Tests', () => {
   beforeEach(() => {
     (useProjectStore as jest.Mock).mockReturnValue(mockStore)
     mockStore.getActiveTab.mockReturnValue(mockTab)
+    // Reset mutable tab state before each test
+    mockTab.canvasState.tool = 'pencil'
+    mockTab.canvasState.zoom = 10
+    mockTab.history = [{}]
+    mockTab.historyIndex = 0
     jest.clearAllMocks()
   })
 

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -33,9 +33,13 @@ class ApiClient {
 
     // Request interceptor for auth
     this.client.interceptors.request.use((config) => {
-      // Add auth token if available
-      const token = localStorage.getItem('auth_token')
+      // Add auth token if available; guard against non-browser environments
+      const token = typeof window !== 'undefined'
+        ? window.localStorage.getItem('auth_token')
+        : null
       if (token) {
+        // Ensure headers object exists before assignment
+        config.headers = config.headers || {}
         config.headers.Authorization = `Bearer ${token}`
       }
       return config

--- a/lib/stores/project-store.ts
+++ b/lib/stores/project-store.ts
@@ -1731,13 +1731,14 @@ export const useProjectStore = create<ProjectStore>()(
             let totalRegenerated = 0
             
             state.tabs.forEach(tab => {
+              const frames = tab.frameCanvasData || []
               debugLog('REGENERATE_TAB_THUMBNAILS', `Regenerating thumbnails for tab ${tab.id}`, {
                 tabId: tab.id,
-                frameCount: tab.frameCanvasData.length,
+                frameCount: frames.length,
                 projectName: tab.project.name
               })
-              
-              tab.frameCanvasData.forEach(frameData => {
+
+              frames.forEach(frameData => {
                 if (frameData.canvasData && frameData.canvasData.data.length > 0) {
                   const newThumbnail = generateThumbnail(frameData.canvasData)
                   if (newThumbnail) {
@@ -1760,7 +1761,10 @@ export const useProjectStore = create<ProjectStore>()(
             
             debugLog('REGENERATE_ALL_THUMBNAILS_COMPLETE', `Regenerated ${totalRegenerated} thumbnails`, {
               totalTabs: state.tabs.length,
-              totalFrames: state.tabs.reduce((sum, tab) => sum + tab.frameCanvasData.length, 0),
+              totalFrames: state.tabs.reduce(
+                (sum, tab) => sum + ((tab.frameCanvasData || []).length),
+                0
+              ),
               regeneratedCount: totalRegenerated
             })
           })
@@ -1812,7 +1816,7 @@ export const useProjectStore = create<ProjectStore>()(
             ...tab,
             canvasData: null, // Don't persist heavy canvas data
             history: [], // Don't persist history
-            frameCanvasData: tab.frameCanvasData.map(frameData => ({
+            frameCanvasData: (tab.frameCanvasData || []).map(frameData => ({
               ...frameData,
               thumbnail: null // Don't persist thumbnails - regenerate on load
             }))


### PR DESCRIPTION
## Summary
- avoid accessing localStorage during SSR in API client and ensure headers exist
- safely handle tabs without frame data when regenerating thumbnails and persisting state
- stabilize toolbar integration tests by resetting mutable mock state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c175534c8832c9a461a7cdf12970e