### PR TITLE
fix pastel palette hex value

### DIFF
--- a/components/color-palette.tsx
+++ b/components/color-palette.tsx
@@ -230,7 +230,7 @@ export function ColorPalette({ className }: ColorPaletteProps) {
             size="sm"
             className="w-full justify-start text-xs"
             onClick={() => {
-              const pastelPalette = ['#FFB3BA', '#FFDFBA', '#FFFFBA', '#BAFFBA', '#BAE1FF', '#FFBAF5', '#D4BAFF', '#BABAFFF']
+              const pastelPalette = ['#FFB3BA', '#FFDFBA', '#FFFFBA', '#BAFFBA', '#BAE1FF', '#FFBAF5', '#D4BAFF', '#BABAFF']
               updateProject(activeTabId, { palette: pastelPalette.slice(0, project.colorLimit) })
             }}
           >


### PR DESCRIPTION
## Summary
- fix typo in pastel color palette hex value

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading 'map'))*
- `npm run lint`
- `npm run type-check` *(fails: Cannot find name 'test')*
- `npm run dev`
- `curl -s http://localhost:3000 | head -n 20 | cut -c1-200`


------
https://chatgpt.com/codex/tasks/task_e_689c1858ebc0832cb49dd8fc8985c266