### PR TITLE
Rename eyedropper tool to color picker

### DIFF
--- a/BROWSER_TEST_SCRIPT.md
+++ b/BROWSER_TEST_SCRIPT.md
@@ -35,7 +35,7 @@ console.log('✅ Canvas click monitoring enabled. Now click on canvas and check 
 console.log('🛠️  STARTING TOOL SELECTION TEST');
 
 // Test tool selection
-const tools = ['Pencil', 'Eraser', 'Paint Bucket', 'Eyedropper', 'Pan'];
+const tools = ['Pencil', 'Eraser', 'Paint Bucket', 'Color Picker', 'Pan'];
 let currentIndex = 0;
 
 function testNextTool() {

--- a/FRONTEND_QA_TESTING_PLAN.md
+++ b/FRONTEND_QA_TESTING_PLAN.md
@@ -24,7 +24,7 @@ localStorage.setItem('pixelbuddy-debug', 'true')
 **Expected Behavior:**
 - ✅ Pencil tool draws pixels immediately
 - ✅ Eraser removes pixels immediately  
-- ✅ Eyedropper picks colors correctly
+- ✅ Color Picker picks colors correctly
 - ✅ Fill tool works on enclosed areas
 
 **Test Steps:**
@@ -33,7 +33,7 @@ localStorage.setItem('pixelbuddy-debug', 'true')
 3. Click on canvas - **pixel should appear immediately**
 4. Draw several pixels in sequence
 5. Switch to eraser, test erasing
-6. Test eyedropper on existing pixels
+6. Test color picker on existing pixels
 7. Test fill tool on empty areas
 
 **Debug Logs to Monitor:**
@@ -57,7 +57,7 @@ localStorage.setItem('pixelbuddy-debug', 'true')
 - ✅ Only one tool active at time
 
 **Test Steps:**
-1. Click each tool button (pencil, eraser, eyedropper, fill, pan)
+1. Click each tool button (pencil, eraser, color picker, fill, pan)
 2. Verify visual feedback (button highlight)
 3. Verify cursor changes on canvas
 4. Test tool functionality
@@ -168,7 +168,7 @@ localStorage.setItem('pixelbuddy-debug', 'true')
 
 ## 📋 **Testing Checklist**
 
-- [ ] **Phase 1**: Canvas drawing (pencil, eraser, eyedropper, fill)
+- [ ] **Phase 1**: Canvas drawing (pencil, eraser, color picker, fill)
 - [ ] **Phase 2**: Tool selection and color palette  
 - [ ] **Phase 3**: Project panel resize functionality
 - [ ] **Phase 4**: Tab management and frames

--- a/QA_TEST_REPORT.md
+++ b/QA_TEST_REPORT.md
@@ -239,7 +239,7 @@ The **critical functionality gaps** have been resolved. The application now has:
 Systematic comparison against DEVELOPMENT_PRD_eng.md:
 
 ### ✅ **FULLY IMPLEMENTED FEATURES**
-- **Drawing System**: Pencil, Eraser, Fill, Eyedropper, Pan tools working
+- **Drawing System**: Pencil, Eraser, Fill, Color Picker, Pan tools working
 - **Canvas Management**: Pixel-perfect rendering with zoom/pan
 - **Project Settings**: Dimension changes, color limits, mode switching
 - **Color Palette**: 24-color system with preset palettes
@@ -287,7 +287,7 @@ Tests: 1 failed, 28 passed, 29 total (96.5% pass rate)
 #### **Core Workflow Testing**:
 
 **1. Basic Drawing Workflow** ✅ **PASS**
-- Drawing tools functional (Pencil, Eraser, Fill, Eyedropper, Pan)
+- Drawing tools functional (Pencil, Eraser, Fill, Color Picker, Pan)
 - Canvas interaction responsive and accurate
 - Undo/redo working properly
 - Zoom controls functional

--- a/TOOLBAR_TEST_RESULTS.md
+++ b/TOOLBAR_TEST_RESULTS.md
@@ -8,7 +8,7 @@
 ### **Component Structure:**
 - **Location:** `/components/toolbar.tsx`
 - **Debug Logging:** ✅ Implemented (lines 50-57)
-- **Tools Available:** 5 tools (Pencil, Eraser, Paint Bucket, Eyedropper, Pan)
+- **Tools Available:** 5 tools (Pencil, Eraser, Paint Bucket, Color Picker, Pan)
 - **Additional Features:** Undo/Redo, Zoom In/Out, Brush Size
 
 ### **Expected Debug Log Categories:**
@@ -29,7 +29,7 @@
 - ✅ Debug logs for tool changes
 
 **Manual Test Steps:**
-1. Click each tool button (Pencil, Eraser, Paint Bucket, Eyedropper, Pan)
+1. Click each tool button (Pencil, Eraser, Paint Bucket, Color Picker, Pan)
 2. Verify button highlight (blue background for active)
 3. Check canvas cursor change
 4. Monitor console for `[TOOL_CHANGE]` logs
@@ -75,7 +75,7 @@
 console.log('🛠️ STARTING TOOLBAR TESTING');
 
 // Test 1: Tool Selection
-const tools = ['Pencil', 'Eraser', 'Paint Bucket', 'Eyedropper', 'Pan'];
+const tools = ['Pencil', 'Eraser', 'Paint Bucket', 'Color Picker', 'Pan'];
 let testIndex = 0;
 
 function testNextTool() {
@@ -162,7 +162,7 @@ testNextTool();
 - [ ] Pencil: Visual feedback ✅/❌, Cursor change ✅/❌
 - [ ] Eraser: Visual feedback ✅/❌, Cursor change ✅/❌  
 - [ ] Paint Bucket: Visual feedback ✅/❌, Cursor change ✅/❌
-- [ ] Eyedropper: Visual feedback ✅/❌, Cursor change ✅/❌
+- [ ] Color Picker: Visual feedback ✅/❌, Cursor change ✅/❌
 - [ ] Pan: Visual feedback ✅/❌, Cursor change ✅/❌
 
 ### Zoom Controls:

--- a/__tests__/toolbar-integration.test.tsx
+++ b/__tests__/toolbar-integration.test.tsx
@@ -49,7 +49,7 @@ describe('Toolbar Integration Tests', () => {
       expect(screen.getByText('Pencil')).toBeInTheDocument()
       expect(screen.getByText('Eraser')).toBeInTheDocument()
       expect(screen.getByText('Paint Bucket')).toBeInTheDocument()
-      expect(screen.getByText('Eyedropper')).toBeInTheDocument()
+      expect(screen.getByText('Color Picker')).toBeInTheDocument()
       expect(screen.getByText('Pan')).toBeInTheDocument()
     })
 

--- a/components/pixel-canvas.tsx
+++ b/components/pixel-canvas.tsx
@@ -142,7 +142,7 @@ export function PixelCanvas({ project, canvasData, canvasState }: PixelCanvasPro
         const b = newData[index + 2] || 0
         const alpha = newData[index + 3] || 0
         
-        debugLog('DRAW_EYEDROPPER_RAW', `Raw pixel data at index ${index}`, {
+        debugLog('DRAW_COLOR_PICKER_RAW', `Raw pixel data at index ${index}`, {
           r, g, b, alpha,
           pixelX, pixelY,
           dataLength: newData.length
@@ -152,7 +152,7 @@ export function PixelCanvas({ project, canvasData, canvasState }: PixelCanvasPro
         let pickedColor: string
         if (alpha === 0) {
           pickedColor = canvasState.color // Keep current color for transparent pixels
-          debugLog('DRAW_EYEDROPPER_TRANSPARENT', `Picked transparent pixel, keeping current color: ${pickedColor}`)
+          debugLog('DRAW_COLOR_PICKER_TRANSPARENT', `Picked transparent pixel, keeping current color: ${pickedColor}`)
         } else {
           // Convert RGB values to hex string with proper padding
           pickedColor = `#${[
@@ -161,7 +161,7 @@ export function PixelCanvas({ project, canvasData, canvasState }: PixelCanvasPro
             Math.max(0, Math.min(255, b)).toString(16).padStart(2, '0')
           ].join('')}`
           
-          debugLog('DRAW_EYEDROPPER_COLOR', `Picked color from pixel`, {
+          debugLog('DRAW_COLOR_PICKER_COLOR', `Picked color from pixel`, {
             originalRGB: { r, g, b, alpha },
             hexColor: pickedColor
           })
@@ -170,7 +170,7 @@ export function PixelCanvas({ project, canvasData, canvasState }: PixelCanvasPro
         // Update the canvas state with the picked color
         updateCanvasState(activeTabId, { color: pickedColor })
         
-        debugLog('DRAW_EYEDROPPER_SUCCESS', `Eyedropper completed successfully`, {
+        debugLog('DRAW_COLOR_PICKER_SUCCESS', `Color Picker completed successfully`, {
           pickedColor,
           coordinatesUsed: { pixelX, pixelY },
           wasTransparent: alpha === 0
@@ -336,7 +336,7 @@ export function PixelCanvas({ project, canvasData, canvasState }: PixelCanvasPro
       }
     } else if (canvasState.tool !== 'eyedropper') {
       // Use same simple coordinate calculation as mouse down
-      // Skip drawing for eyedropper tool - it should only work on click, not drag
+      // Skip drawing for color picker tool - it should only work on click, not drag
       const canvasRect = canvasRef.current.getBoundingClientRect()
       const x = e.clientX - canvasRect.left
       const y = e.clientY - canvasRect.top
@@ -605,7 +605,7 @@ export function PixelCanvas({ project, canvasData, canvasState }: PixelCanvasPro
         
         {/* Tool indicator */}
         <div className="absolute -top-8 left-0 rounded bg-black/75 px-2 py-1 text-xs text-white">
-          {canvasState.tool === 'eyedropper' ? 'eyedropper - click to pick color' : 
+          {canvasState.tool === 'eyedropper' ? 'Color Picker - click to pick color' :
            `${canvasState.tool} | ${canvasState.zoom}x`}
         </div>
       </div>

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -8,7 +8,7 @@ import {
   Pencil,
   Eraser,
   Paintbrush,
-  Droplets,
+  Pipette,
   Move,
   RotateCcw,
   RotateCw,
@@ -31,7 +31,7 @@ const tools: Array<{
   { id: 'pencil', name: 'Pencil', icon: Pencil, shortcut: 'P' },
   { id: 'eraser', name: 'Eraser', icon: Eraser, shortcut: 'E' },
   { id: 'fill', name: 'Paint Bucket', icon: Paintbrush, shortcut: 'B' },
-  { id: 'eyedropper', name: 'Eyedropper', icon: Droplets, shortcut: 'I' },
+  { id: 'eyedropper', name: 'Color Picker', icon: Pipette, shortcut: 'I' },
   { id: 'pan', name: 'Pan', icon: Move, shortcut: 'H' },
 ]
 

--- a/test-functional.js
+++ b/test-functional.js
@@ -857,10 +857,10 @@ async function testColorPicker(page) {
   const result = { status: 'unknown', details: [], issues: [] };
   
   try {
-    // Look for eyedropper/color picker tool
+    // Look for color picker tool
     const pickerSelectors = [
       '[data-testid="eyedropper"]',
-      'button:has-text("Eyedropper")',
+      'button:has-text("Color Picker")',
       '[aria-label*="pick color"]',
       '[title*="color picker"]'
     ];


### PR DESCRIPTION
## Summary
- Rename Eyedropper tool to Color Picker and switch icon to pipette for kid-friendly clarity
- Update canvas tooltip, docs, and tests to reference Color Picker

## Testing
- `npm test` *(fails: Unable to find element with text /Current: 10\.0x/; TypeError: Cannot read properties of undefined (reading 'map'))*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c192b2408832c84b3df6079cb6fd3