### PR TITLE
Add integration tests for additional toolbar tools

### DIFF
--- a/__tests__/toolbar-integration.test.tsx
+++ b/__tests__/toolbar-integration.test.tsx
@@ -69,11 +69,38 @@ describe('Toolbar Integration Tests', () => {
 
     test('should call updateCanvasState when eraser is clicked', () => {
       render(<Toolbar />)
-      
+
       const eraserButton = screen.getByText('Eraser')
       fireEvent.click(eraserButton)
-      
+
       expect(mockStore.updateCanvasState).toHaveBeenCalledWith('test-tab', { tool: 'eraser' })
+    })
+
+    test('should call updateCanvasState when paint bucket is clicked', () => {
+      render(<Toolbar />)
+
+      const fillButton = screen.getByText('Paint Bucket')
+      fireEvent.click(fillButton)
+
+      expect(mockStore.updateCanvasState).toHaveBeenCalledWith('test-tab', { tool: 'fill' })
+    })
+
+    test('should call updateCanvasState when color picker is clicked', () => {
+      render(<Toolbar />)
+
+      const eyedropperButton = screen.getByText('Color Picker')
+      fireEvent.click(eyedropperButton)
+
+      expect(mockStore.updateCanvasState).toHaveBeenCalledWith('test-tab', { tool: 'eyedropper' })
+    })
+
+    test('should call updateCanvasState when pan is clicked', () => {
+      render(<Toolbar />)
+
+      const panButton = screen.getByText('Pan')
+      fireEvent.click(panButton)
+
+      expect(mockStore.updateCanvasState).toHaveBeenCalledWith('test-tab', { tool: 'pan' })
     })
 
     test('should highlight active tool', () => {


### PR DESCRIPTION
## Summary
- test clicking Fill, Eyedropper, and Pan buttons updates canvas state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c1d9ff578832ca3b3ef4fe592d295